### PR TITLE
Update canvas-raycaster README.md

### DIFF
--- a/canvas-raycaster/README.md
+++ b/canvas-raycaster/README.md
@@ -1,4 +1,4 @@
 # canvas-raycaster
-A demo using the [&lt;canvas>](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API) element to do software rendering of a 3D environment with ray-casting. For more information, read the MDN article "[A basic ray-caster"](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/A_basic_ray-caster).
+This is a demo using the [&lt;canvas>](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API) element to do software rendering of a 3D environment with ray-casting. For more information, read the article "[A basic ray-caster"](https://github.com/mdn/museum/blob/main/canvas-raycaster/a_basic_raycaster/index.md) on Github.
 
 You can try this ray-caster here: [demo](http://mdn.github.io/canvas-raycaster/).


### PR DESCRIPTION
Updated the readme to update the link to the article.
The article was moved (copied for now) from `mdn/content` to `mdn/museum/canvas-raycaster` in https://github.com/mdn/museum/pull/1