### PR TITLE
chore: update links to point to live example on museum

### DIFF
--- a/webvr/README.md
+++ b/webvr/README.md
@@ -3,10 +3,10 @@ Simple tests for testing WebVR functionality. See [https://developer.mozilla.org
 
 The tests are as follows:
 
-* [basic-display-info](https://mdn.github.io/webvr-tests/basic-display-info/) — Demo that detects all VRDisplays connected to the computer and displays all their basic capabilities.
-* [field-of-view-test](https://mdn.github.io/webvr-tests/field-of-view-test/) — Demo that detects the first VRDisplay connected to the computer and displays its field of view information.
-* [stage-parameters-test](https://mdn.github.io/webvr-tests/stage-parameters-test/) — Demo that detects the first VRDisplay connected to the computer and displays its stage parameterss.
-* [raw-webgl-example](https://mdn.github.io/webvr-tests/raw-webgl-example/) — A quick 'n' dirty example that shows the basics of how to use the WebVR API.
-* [vr-controller-basic-info](https://mdn.github.io/webvr-tests/vr-controller-basic-info/) — Demo that detects and outputs information about VRDisplays and associated controllers connected to your computer.
-* [raw-webgl-controller-example](https://mdn.github.io/webvr-tests/raw-webgl-controller-example/) — A quick 'n' dirty example that shows the basics of how to use the WebVR API along with the Gamepad API to control objects in 3D space.
-* [aframe-demo](https://mdn.github.io/webvr-tests/aframe-demo/) — A simple WebVR demo that uses [Mozilla's A-Frame](https://aframe.io/) framework to create a scene.
+* [basic-display-info](https://mdn.github.io/museum/webvr/basic-display-info/) — Demo that detects all VRDisplays connected to the computer and displays all their basic capabilities.
+* [field-of-view-test](https://mdn.github.io/museum/webvr/field-of-view-test/) — Demo that detects the first VRDisplay connected to the computer and displays its field of view information.
+* [stage-parameters-test](https://mdn.github.io/museum/webvr/stage-parameters-test/) — Demo that detects the first VRDisplay connected to the computer and displays its stage parameterss.
+* [raw-webgl-example](https://mdn.github.io/museum/webvr/raw-webgl-example/) — A quick 'n' dirty example that shows the basics of how to use the WebVR API.
+* [vr-controller-basic-info](https://mdn.github.io/museum/webvr/vr-controller-basic-info/) — Demo that detects and outputs information about VRDisplays and associated controllers connected to your computer.
+* [raw-webgl-controller-example](https://mdn.github.io/museum/webvr/raw-webgl-controller-example/) — A quick 'n' dirty example that shows the basics of how to use the WebVR API along with the Gamepad API to control objects in 3D space.
+* [aframe-demo](https://mdn.github.io/museum/webvr/aframe-demo/) — A simple WebVR demo that uses [Mozilla's A-Frame](https://aframe.io/) framework to create a scene.


### PR DESCRIPTION
Update links to point to live examples on museum